### PR TITLE
Add Usage & ROI panel to Billing Settings with annual savings CTA

### DIFF
--- a/frontend/src/pages/settings/BillingSettings.js
+++ b/frontend/src/pages/settings/BillingSettings.js
@@ -1,67 +1,61 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { PageErrorBoundary } from '../../components/withErrorBoundary';
 import { CreditCardIcon, ClockIcon, DocumentTextIcon } from '@heroicons/react/24/outline';
 
+const planOptions = [
+  {
+    name: 'Basic',
+    description: 'Limited applications',
+    price: '$9.99',
+    period: '/mo',
+    isCurrent: false
+  },
+  {
+    name: 'Pro Plus',
+    description: 'Unlimited applications',
+    price: '$19.99',
+    period: '/mo',
+    isCurrent: true
+  },
+  {
+    name: 'Enterprise',
+    description: 'Team features & API access',
+    price: '$49.99',
+    period: '/mo',
+    isCurrent: false
+  }
+];
+
+const billingHistory = [
+  { id: 'inv_2025_05', date: '2025-05-24', amount: '$19.99', status: 'Paid' },
+  { id: 'inv_2025_04', date: '2025-04-24', amount: '$19.99', status: 'Paid' },
+  { id: 'inv_2025_03', date: '2025-03-24', amount: '$19.99', status: 'Paid' }
+];
+
+const formatDate = (dateString) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  });
+};
+
+const getNextRenewalDate = (latestInvoiceDate) => {
+  const renewalDate = new Date(latestInvoiceDate);
+  renewalDate.setMonth(renewalDate.getMonth() + 1);
+  return formatDate(renewalDate.toISOString());
+};
+
 const BillingSettings = () => {
-  const usageStats = [
-    { label: 'AI Cover Letter Credits', used: 84, total: 100 },
-    { label: 'JD Analysis Credits', used: 36, total: 50 },
-    { label: 'Resume Tailoring Requests', used: 22, total: 30 }
-  ];
-
-  const annualSavings = ((19.99 * 12) - (15.99 * 12)).toFixed(2);
-
-  const getUsagePercentage = (used, total) => Math.min(100, Math.round((used / total) * 100));
+  const nextRenewalDate = getNextRenewalDate(billingHistory[0].date);
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 mb-2">Billing & Subscription</h1>
         <p className="text-gray-600">Manage your payment methods and subscription plans</p>
-      </div>
-
-      {/* Usage & ROI */}
-      <div className="bg-white shadow rounded-lg p-6 mb-6">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Usage & Value</h2>
-            <p className="text-sm text-gray-600">Track monthly usage and estimated ROI from your plan.</p>
-          </div>
-          <div className="rounded-md bg-primary-50 border border-primary-100 px-4 py-3">
-            <p className="text-xs text-primary-700 font-medium uppercase tracking-wide">Estimated Monthly Time Saved</p>
-            <p className="text-2xl font-bold text-primary-700">11.5 hours</p>
-          </div>
-        </div>
-
-        <div className="space-y-4">
-          {usageStats.map((item) => (
-            <div key={item.label}>
-              <div className="flex justify-between items-center text-sm mb-1">
-                <span className="font-medium text-gray-800">{item.label}</span>
-                <span className="text-gray-600">{item.used}/{item.total}</span>
-              </div>
-              <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-primary-500 rounded-full"
-                  style={{ width: `${getUsagePercentage(item.used, item.total)}%` }}
-                />
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <div className="mt-6 rounded-md border border-emerald-200 bg-emerald-50 p-4">
-          <h3 className="text-sm font-semibold text-emerald-800">Switch to annual and save ${annualSavings}/year</h3>
-          <p className="text-sm text-emerald-700 mt-1">
-            Get the same Pro Plus features at <span className="font-semibold">$15.99/month (billed annually)</span>.
-          </p>
-          <button
-            type="button"
-            className="mt-3 inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-white bg-emerald-600 hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500"
-          >
-            Upgrade to Annual Plan
-          </button>
-        </div>
       </div>
 
       {/* Current Plan */}
@@ -92,9 +86,7 @@ const BillingSettings = () => {
               <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
                 Active
               </span>
-              <p className="mt-1 text-xs text-gray-600">
-                Renews on June 24, 2025
-              </p>
+              <p className="mt-1 text-xs text-gray-600">Renews on {nextRenewalDate}</p>
             </div>
           </div>
 
@@ -117,22 +109,28 @@ const BillingSettings = () => {
         <div className="mt-4">
           <h3 className="text-md font-medium text-gray-900 mb-2">Available Plans</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="border border-gray-200 rounded-md p-4 hover:border-primary-300 hover:shadow-sm cursor-pointer transition">
-              <h4 className="font-medium text-gray-900">Basic</h4>
-              <p className="text-sm text-gray-600 mt-1">Limited applications</p>
-              <p className="mt-2 text-lg font-semibold text-primary-600">$9.99<span className="text-sm text-gray-500">/mo</span></p>
-            </div>
-            <div className="border-2 border-primary-500 rounded-md p-4 relative shadow-sm">
-              <div className="absolute -top-3 left-4 bg-primary-500 text-white text-xs font-bold px-2 py-0.5 rounded">Current</div>
-              <h4 className="font-medium text-gray-900">Pro Plus</h4>
-              <p className="text-sm text-gray-600 mt-1">Unlimited applications</p>
-              <p className="mt-2 text-lg font-semibold text-primary-600">$19.99<span className="text-sm text-gray-500">/mo</span></p>
-            </div>
-            <div className="border border-gray-200 rounded-md p-4 hover:border-primary-300 hover:shadow-sm cursor-pointer transition">
-              <h4 className="font-medium text-gray-900">Enterprise</h4>
-              <p className="text-sm text-gray-600 mt-1">Team features & API access</p>
-              <p className="mt-2 text-lg font-semibold text-primary-600">$49.99<span className="text-sm text-gray-500">/mo</span></p>
-            </div>
+            {planOptions.map((plan) => (
+              <div
+                key={plan.name}
+                className={`rounded-md p-4 transition ${
+                  plan.isCurrent
+                    ? 'border-2 border-primary-500 relative shadow-sm'
+                    : 'border border-gray-200 hover:border-primary-300 hover:shadow-sm cursor-pointer'
+                }`}
+              >
+                {plan.isCurrent && (
+                  <div className="absolute -top-3 left-4 bg-primary-500 text-white text-xs font-bold px-2 py-0.5 rounded">
+                    Current
+                  </div>
+                )}
+                <h4 className="font-medium text-gray-900">{plan.name}</h4>
+                <p className="text-sm text-gray-600 mt-1">{plan.description}</p>
+                <p className="mt-2 text-lg font-semibold text-primary-600">
+                  {plan.price}
+                  <span className="text-sm text-gray-500">{plan.period}</span>
+                </p>
+              </div>
+            ))}
           </div>
         </div>
       </div>
@@ -209,61 +207,34 @@ const BillingSettings = () => {
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              <tr>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                  May 24, 2025
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                  $19.99
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap">
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                    Paid
-                  </span>
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-primary-600 hover:text-primary-700">
-                  <a href="#" className="underline">View Invoice</a>
-                </td>
-              </tr>
-              <tr>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                  April 24, 2025
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                  $19.99
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap">
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                    Paid
-                  </span>
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-primary-600 hover:text-primary-700">
-                  <a href="#" className="underline">View Invoice</a>
-                </td>
-              </tr>
-              <tr>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                  March 24, 2025
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                  $19.99
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap">
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                    Paid
-                  </span>
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-primary-600 hover:text-primary-700">
-                  <a href="#" className="underline">View Invoice</a>
-                </td>
-              </tr>
+              {billingHistory.map((invoice) => (
+                <tr key={invoice.id}>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{formatDate(invoice.date)}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{invoice.amount}</td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                      {invoice.status}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-primary-600 hover:text-primary-700">
+                    <button type="button" className="underline" aria-label={`View invoice ${invoice.id}`}>
+                      View Invoice
+                    </button>
+                  </td>
+                </tr>
+              ))}
             </tbody>
           </table>
         </div>
       </div>
 
       <div className="mt-4 text-sm text-gray-600">
-        <p>Having issues with your billing? <a href="#" className="text-primary-600 hover:text-primary-700 underline">Contact support</a></p>
+        <p>
+          Having issues with your billing?{' '}
+          <Link to="/help" className="text-primary-600 hover:text-primary-700 underline">
+            Contact support
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/pages/settings/BillingSettings.js
+++ b/frontend/src/pages/settings/BillingSettings.js
@@ -3,11 +3,65 @@ import { PageErrorBoundary } from '../../components/withErrorBoundary';
 import { CreditCardIcon, ClockIcon, DocumentTextIcon } from '@heroicons/react/24/outline';
 
 const BillingSettings = () => {
+  const usageStats = [
+    { label: 'AI Cover Letter Credits', used: 84, total: 100 },
+    { label: 'JD Analysis Credits', used: 36, total: 50 },
+    { label: 'Resume Tailoring Requests', used: 22, total: 30 }
+  ];
+
+  const annualSavings = ((19.99 * 12) - (15.99 * 12)).toFixed(2);
+
+  const getUsagePercentage = (used, total) => Math.min(100, Math.round((used / total) * 100));
+
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-gray-900 mb-2">Billing & Subscription</h1>
         <p className="text-gray-600">Manage your payment methods and subscription plans</p>
+      </div>
+
+      {/* Usage & ROI */}
+      <div className="bg-white shadow rounded-lg p-6 mb-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">Usage & Value</h2>
+            <p className="text-sm text-gray-600">Track monthly usage and estimated ROI from your plan.</p>
+          </div>
+          <div className="rounded-md bg-primary-50 border border-primary-100 px-4 py-3">
+            <p className="text-xs text-primary-700 font-medium uppercase tracking-wide">Estimated Monthly Time Saved</p>
+            <p className="text-2xl font-bold text-primary-700">11.5 hours</p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {usageStats.map((item) => (
+            <div key={item.label}>
+              <div className="flex justify-between items-center text-sm mb-1">
+                <span className="font-medium text-gray-800">{item.label}</span>
+                <span className="text-gray-600">{item.used}/{item.total}</span>
+              </div>
+              <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-primary-500 rounded-full"
+                  style={{ width: `${getUsagePercentage(item.used, item.total)}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-6 rounded-md border border-emerald-200 bg-emerald-50 p-4">
+          <h3 className="text-sm font-semibold text-emerald-800">Switch to annual and save ${annualSavings}/year</h3>
+          <p className="text-sm text-emerald-700 mt-1">
+            Get the same Pro Plus features at <span className="font-semibold">$15.99/month (billed annually)</span>.
+          </p>
+          <button
+            type="button"
+            className="mt-3 inline-flex items-center px-4 py-2 rounded-md text-sm font-medium text-white bg-emerald-600 hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500"
+          >
+            Upgrade to Annual Plan
+          </button>
+        </div>
       </div>
 
       {/* Current Plan */}


### PR DESCRIPTION
### Motivation
- Surface monthly usage and estimated ROI to help users understand value and encourage annual upgrades.

### Description
- Introduced a `usageStats` array, an `annualSavings` calculation, and a `getUsagePercentage` helper to compute progress widths.
- Added a new "Usage & Value" panel to `BillingSettings.js` showing an "Estimated Monthly Time Saved" badge and mapped usage progress bars for each credit type.
- Added an annual plan promotion section with the computed savings and an "Upgrade to Annual Plan" call-to-action button.
- Kept styling consistent with existing Tailwind classes and existing icons from `@heroicons/react`.

### Testing
- Ran `npm test` for the frontend test suite and all tests passed.
- Ran `npm run lint` and there were no linting errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a45dfc9d088325a082630c6002f7b7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Usage & ROI" section displaying usage statistics and progress tracking
  * Shows estimated monthly time saved and annual savings metrics
  * Added annual billing option toggle
  * Billing page now renders plan options and billing history dynamically, with clear current-plan badge, renewal date, and per-invoice view controls
  * Contact support link in Billing History navigates to the Help page
<!-- end of auto-generated comment: release notes by coderabbit.ai -->